### PR TITLE
Fix button typo and settings bug

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -127,20 +127,20 @@ const App = () => {
           sessionSettings={sessionSettings}
         />}
         
-      <buttton className={`${openPanel !== 'none' ? 'hidden' : 'block'} border border-2 border-sky-700 m-2 p-2 absolute right-0 top-0 w-12 bg-stone-800 h-12`}>
+      <button className={`${openPanel !== 'none' ? 'hidden' : 'block'} border border-2 border-sky-700 m-2 p-2 absolute right-0 top-0 w-12 bg-stone-800 h-12`}>
         <img
           className='cursor-pointer transform rotate-0 hover:rotate-45 transition-transform duration-300 ease-in-out'
           src={settingsBtn}
           alt='settings'
           onClick={() => setOpenPanel('settings')}/>
-      </buttton>
-      <buttton className={`${openPanel !== 'none' ? 'hidden' : 'block'} border border-2 border-sky-700 m-2 p-2 mr-16 absolute right-0 top-0 w-12 bg-stone-800 h-12`}>
+      </button>
+      <button className={`${openPanel !== 'none' ? 'hidden' : 'block'} border border-2 border-sky-700 m-2 p-2 mr-16 absolute right-0 top-0 w-12 bg-stone-800 h-12`}>
         <img
           className='cursor-pointer transform scale-100 hover:scale-110 transition-transform duration-300 ease-in-out'
           src={aboutBtn}
           alt='settings'
           onClick={() => setOpenPanel('about')}/>
-      </buttton>
+      </button>
 
 
       <SettingsPanel

--- a/src/settings/defaults.js
+++ b/src/settings/defaults.js
@@ -17,7 +17,6 @@ const defaultSettings = {
         'animateClouds': true,
         'showCenterLine': true,
         'showOrbits': true,
-        'animateClouds': true,
         'cloudOpacity': 0.6,
         'doDayLightCycle': true,
     },


### PR DESCRIPTION
## Summary
- fix invalid `<button>` markup in `App.jsx`
- remove duplicate `animateClouds` option from default settings

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: vite not found)*