### PR TITLE
Add satellite pass predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ to start a copy.
 ## Interface and Usage
 Galileo displays a fullscreen rendering of earth and sattelites using [@react-three-fiber](https://github.com/pmndrs/react-three-fiber) and [Tailwind.css](https://tailwindcss.com/) to style the page. Galileo allows for past & future date manipulation and provides many keyboard shortcuts for users to navigate between objects. Galileo features other visuals such as orbit displays, a dynamic hexasphere, and more.
 
+### Viewing Satellite Passes
+Select a satellite to see orbital details and a list of upcoming passes over your configured observer location. The pass list shows the start and end times along with the maximum elevation for the next 24&nbsp;hours.
+
 ## Possible Future Updates
 Galileo may be updated in the future to allow use with live sensors & data and/or the ability to control local communication devices.
 

--- a/src/components/SelectedObjectInfoBox.jsx
+++ b/src/components/SelectedObjectInfoBox.jsx
@@ -11,6 +11,20 @@ const SelectedObjectInfoBox = (props) => {
   var gmst = satlib.gstime(props.simulatedDatestamp)
   var positionGd = satlib.eciToGeodetic(posECI, gmst)
 
+  const [passList, setPassList] = useState([])
+
+  useEffect(() => {
+    const passes = utils.predictPasses(
+      props.object,
+      props.sessionSettings.general.latitude,
+      props.sessionSettings.general.longitude,
+      new Date(),
+      24,
+      1
+    )
+    setPassList(passes.slice(0, 3))
+  }, [props.object, props.sessionSettings])
+
   function readTLE() {
     var tle1 = props.object.line1.split(/\s+/)
     var tle2 = props.object.line2.split(/\s+/)
@@ -66,6 +80,17 @@ const SelectedObjectInfoBox = (props) => {
       <p>Arg of Perigee: {readTLE().argOfPerigee + '\u00B0'}</p>
       <p>Mean Anomaly: {readTLE().meanAnomaly + '\u00B0'}</p>
       <p>Mean Motion: {readTLE().meanMotion}</p>
+      {passList.length > 0 &&
+        <div className='mt-2'>
+          <p className='font-semibold'>Upcoming Passes:</p>
+          {passList.map((p, idx) => (
+            <div key={idx} className='ml-2'>
+              <p>Start: {p.start.toUTCString()}</p>
+              <p>End: {p.end.toUTCString()}</p>
+              <p>Max Elev: {utils.roundToDecimal(p.maxElevation, 1)}&#176; at {p.maxTime.toUTCString()}</p>
+            </div>
+          ))}
+        </div>}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- compute future passes with new `predictPasses` util
- show upcoming passes in selected object box
- document how to view passes

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*